### PR TITLE
Fix new deployment with default files

### DIFF
--- a/amon/settings.py
+++ b/amon/settings.py
@@ -174,6 +174,14 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 LOGFILE = '/var/log/amon/amonapp.log'
 LOGFILE_REQUESTS = '/var/log/amon/amon_requests.log'
 
+with os.path.abspath(os.path.dirname(LOGFILE)) as path:
+    if not os.path.isdir(path):
+        os.system('mkdir -p {}'.format(path))
+
+with os.path.abspath(os.path.dirname(LOGFILE_REQUESTS)) as path:
+    if not os.path.isdir(path):
+        os.system('mkdir -p {}'.format(path))
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/amon/settings.py
+++ b/amon/settings.py
@@ -182,6 +182,14 @@ DATABASES = {
 }
 
 config_path = "/etc/opt/amon/amon.yml"
+with os.path.abspath(os.path.dirname(config_path)) as path:
+    if not os.path.isdir(path):
+        os.system('mkdir -p {}'.format(path))
+with os.path.isfile(os.path.abspath(config_path)) as config_file:
+    if not os.path.isfile(config_file):
+        os.system('cp {}/amon.yml {}'.format(
+            PROJECT_ROOT, config_file
+        ))
 
 # Overwrite for the test suite
 if TESTING:

--- a/amon/settings.py
+++ b/amon/settings.py
@@ -174,13 +174,13 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 LOGFILE = '/var/log/amon/amonapp.log'
 LOGFILE_REQUESTS = '/var/log/amon/amon_requests.log'
 
-with os.path.abspath(os.path.dirname(LOGFILE)) as path:
-    if not os.path.isdir(path):
-        os.system('mkdir -p {}'.format(path))
+log_path = os.path.abspath(os.path.dirname(LOGFILE))
+if not os.path.isdir(log_path):
+    os.system('mkdir -p {}'.format(log_path))
 
-with os.path.abspath(os.path.dirname(LOGFILE_REQUESTS)) as path:
-    if not os.path.isdir(path):
-        os.system('mkdir -p {}'.format(path))
+log_request_path = os.path.abspath(os.path.dirname(LOGFILE_REQUESTS))
+if not os.path.isdir(log_request_path):
+    os.system('mkdir -p {}'.format(log_request_path))
 
 DATABASES = {
     'default': {
@@ -190,14 +190,13 @@ DATABASES = {
 }
 
 config_path = "/etc/opt/amon/amon.yml"
-with os.path.abspath(os.path.dirname(config_path)) as path:
-    if not os.path.isdir(path):
-        os.system('mkdir -p {}'.format(path))
-with os.path.isfile(os.path.abspath(config_path)) as config_file:
-    if not os.path.isfile(config_file):
-        os.system('cp {}/amon.yml {}'.format(
-            PROJECT_ROOT, config_file
-        ))
+config_file_path = os.path.abspath(os.path.dirname(config_path))
+if not os.path.isdir(config_file_path):
+    os.system('mkdir -p {}'.format(config_file_path))
+if not os.path.isfile(os.path.abspath(config_path)):
+    os.system('cp {}/amon.yml {}'.format(
+        PROJECT_ROOT, os.path.abspath(config_path)
+    ))
 
 # Overwrite for the test suite
 if TESTING:


### PR DESCRIPTION
Create default paths for config file and logs
If paths for both are protected (such as /etc or /var) this won't create them.

Also copy the default path (from project root) amon.yml to config dir if there isn't one