### PR TITLE
Fix get table data pymongo

### DIFF
--- a/amon/apps/plugins/models.py
+++ b/amon/apps/plugins/models.py
@@ -590,7 +590,7 @@ class PluginModel(BaseModel):
 
             if keys:
                 result['header'] = keys
-                result['data'] = query
+                result['data'] = [element for element in query]
 
         return result
 

--- a/amon/apps/settings/forms.py
+++ b/amon/apps/settings/forms.py
@@ -18,8 +18,10 @@ CHECK_CHOICES = [
     (15, '15 seconds'), 
     (30, '30 seconds'), 
     (60, '1 minute'),
-    (300, '3 minutes'),
-    (1800, '5 minutes'), 
+    (180, '3 minutes'),
+    (300, '5 minutes'),
+    (900, '15 minutes'),
+    (1800, '30 minutes'),
 ]
 
 if settings.DEBUG == True:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ pycrypto==2.6.1
 # Deployment
 gunicorn==19.6.0
 gevent==1.2.0
-wheel==0.29.0
 
 # Cloud
 xmltodict==0.10.2


### PR DESCRIPTION
Plugin view "GetTableData" returned result['data'] as pymongo's cursor query.

Pymongo's cursor query is read-once. So data got lost somewhere in the process.

I replaced the assginment with [element for element in query], so a list with the results is made, iterable as the query results, but will keep the data after being read.